### PR TITLE
fix: include flag to audit changelog file

### DIFF
--- a/operations.go
+++ b/operations.go
@@ -130,6 +130,7 @@ func resolveVersionFromGit(options NewVersionOptions, git gitCli, newChange *cha
 			options.GitWorkingDirectory,
 			options.ChangelogFile,
 			options.Depth,
+			options.AuditClogFile,
 			newChange,
 			git,
 		)
@@ -218,11 +219,17 @@ func update(ignoreUnknown bool) {
 			options.GitWorkingDirectory,
 			options.ChangelogFile,
 			options.Depth,
+			options.AuditClogFile,
 			unreleased,
 			git,
 		)
 		if err != nil {
 			sLogger.Fatal(err.Error())
+		}
+
+		if len(unreleased.Added) == 0 && len(unreleased.Changed) == 0 && len(unreleased.Deprecated) == 0 && len(unreleased.Removed) == 0 && len(unreleased.Fixed) == 0 && len(unreleased.Security) == 0 {
+			sLogger.Info("No trackable changes to be added to the changelog file. Exiting without changes.")
+			os.Exit(0)
 		}
 
 		unreleased.renderChangeText(*increment)
@@ -269,6 +276,7 @@ func loadConventionalCommitsToChange(
 	dir,
 	changelogFile string,
 	depth int,
+	auditClogFile bool,
 	change *change,
 	git gitCli,
 ) (*string, error) {
@@ -279,25 +287,25 @@ func loadConventionalCommitsToChange(
 	}
 
 	for fixed, message := range fixedUnique {
-		if dir+fixed != changelogFile {
+		if dir+fixed != changelogFile || auditClogFile {
 			change.Fixed = append(change.Fixed, fmt.Sprintf("- %s; %s", fixed, message))
 		}
 	}
 
 	for added, message := range addedUnique {
-		if dir+added != changelogFile {
+		if dir+added != changelogFile || auditClogFile {
 			change.Added = append(change.Added, fmt.Sprintf("- %s; %s", added, message))
 		}
 	}
 
 	for changed, message := range changedUnique {
-		if dir+changed != changelogFile {
+		if dir+changed != changelogFile || auditClogFile {
 			change.Changed = append(change.Changed, fmt.Sprintf("- %s; %s", changed, message))
 		}
 	}
 
 	for removed, message := range removedUnique {
-		if dir+removed != changelogFile {
+		if dir+removed != changelogFile || auditClogFile {
 			change.Removed = append(change.Removed, fmt.Sprintf("- %s; %s", removed, message))
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -58,6 +58,7 @@ type NewVersionOptions struct {
 	Fixed                     []string `short:"x" long:"fixed" description:"What was fixed in this new release?"`
 	Security                  []string `short:"e" long:"security" description:"What was security related in this new release?"`
 	Depth                     int      `short:"d" long:"depth" description:"How deep to go when checking that all commits are conventional" default:"0"`
+	AuditClogFile             bool     `short:"u" long:"audit-changelog-file" description:"If there are changes to the changelog file, should these be included in the changelog?"`
 }
 
 type PrintChangesOptions struct {
@@ -77,8 +78,9 @@ type GitLookupOptions struct {
 type UpdateOptions struct {
 	GlobalOptions
 	GitLookupOptions
-	GitBranch string `short:"b" long:"git-branch" description:"Git branch to run against"`
-	Depth     int    `short:"d" long:"depth" description:"How deep to go when checking that all commits are conventional" default:"0"`
+	GitBranch     string `short:"b" long:"git-branch" description:"Git branch to run against"`
+	Depth         int    `short:"d" long:"depth" description:"How deep to go when checking that all commits are conventional" default:"0"`
+	AuditClogFile bool   `short:"u" long:"audit-changelog-file" description:"If there are changes to the changelog file, should these be included in the changelog?"`
 }
 
 // ReleaseOptions are the options used by the release operation


### PR DESCRIPTION
When changes only occur to the changelog file, the tool panics during the text rendering stage. This PR allows for this to be expected behaviour and exits graceful with 0. Example of graceful exit:
 
![Screenshot 2022-08-02 at 17 30 02](https://user-images.githubusercontent.com/53898669/182425966-2c9548dd-6a41-408d-bf79-2448adf01b40.png)

As well as this, this PR adds the option to include tracking for all changes to the changelog file. An example use case for this is when adding the tool, the only change may be adding the file itself. Some may wish for this to be visible:

![Screenshot 2022-08-02 at 17 16 53](https://user-images.githubusercontent.com/53898669/182423412-50b4e285-57aa-4b1c-ae85-29c5ee3d105e.png)

This is configurable based on a new flag `-u`. This defaults to false unless provided. 

